### PR TITLE
Explicitly specify conda-forge channel in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: ftnlcalib
 channels:
+  - conda-forge
   - robotology
 dependencies:
   - idyntree=10.0.0


### PR DESCRIPTION
`idyntree` is installed by the `conda-forge` channel. This channel is available by default when using `miniforge3` or `mambaforge`, but it is better to explicitly indicate it for people trying to install the environment from anaconda or miniconda distributions.